### PR TITLE
Fix config file new line

### DIFF
--- a/files/opt/flowforge/etc/flowforge.yml
+++ b/files/opt/flowforge/etc/flowforge.yml
@@ -62,3 +62,4 @@ broker:
 
 fileStore:
   url: http://file-server:3001
+


### PR DESCRIPTION
First run script doesn't add a required new line before adding the email config, added a new line to the end of the default file.