### PR TITLE
Fix default secure port

### DIFF
--- a/files/opt/flowforge/first-login.sh
+++ b/files/opt/flowforge/first-login.sh
@@ -68,7 +68,7 @@ select email in "Yes" "No"; do
 
         SMTPSECURE=false
 
-        if [ ${SMTPPORT} -eq 485 ]; then 
+        if [ ${SMTPPORT} -eq 465 ]; then 
             SMTPSECURE=true
         fi
 


### PR DESCRIPTION
typo had 485 instead of 465

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

