### PR TITLE
Make market update script fail the build if it fails

### DIFF
--- a/scripts/market-place-submit.sh
+++ b/scripts/market-place-submit.sh
@@ -24,7 +24,7 @@ echo ${FF_VERSION}
 
 echo https://api.digitalocean.com/api/v1/vendor-portal/apps/${APP_ID}/versions/${FF_VERSION}
 
-curl -X PATCH -H "Content-Type: application/json" -H "Authorization: Bearer ${DIGITALOCEAN_API_TOKEN}" \
+curl --fail-with-body -X PATCH -H "Content-Type: application/json" -H "Authorization: Bearer ${DIGITALOCEAN_API_TOKEN}" \
   -d @update.json  https://api.digitalocean.com/api/v1/vendor-portal/apps/${APP_ID}/versions/${FF_VERSION}
 
 rm update.json


### PR DESCRIPTION
fixes #53

## Description

<!-- Describe your changes in detail -->
Currently the action completes cleanly even if the marketplace update fails. This should fail the action so it alerts the release manager that there is a problem with the market place

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#53

