### PR TITLE
Remove marketplace update script as it will always fail

### DIFF
--- a/template.json
+++ b/template.json
@@ -88,15 +88,5 @@
       "type": "manifest",
       "output": "manifest.json",
       "strip_path": true
-    },
-    {
-      "type": "shell-local",
-      "environment_vars": [
-        "application_version={{user `application_version`}}"
-      ],
-      "scripts": [
-        "scripts/market-place-submit.sh"
-      ]
     }
-  ]
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Remove the script that attempts to update the marketplace as there is no way to get the current version number from the marketplace