### PR TITLE
ci: Fix the value type in the marketplace update json file

### DIFF
--- a/scripts/market-place-submit.sh
+++ b/scripts/market-place-submit.sh
@@ -11,7 +11,7 @@ cat << EOF > update.json
 {
   "reasonForUpdate": "new release",
   "version": "${FF_VERSION}",
-  "imageId": "${IMAGE_ID}",
+  "imageId": ${IMAGE_ID},
   "softwareIncluded": [
     { "name": "FlowFuse", "version": "${FF_VERSION}", "releaseNotes": "https://github.com/FlowFuse/flowfuse/releases/tag/v${FF_VERSION}" },
     { "name": "Ubuntu", "version": "22.04" },


### PR DESCRIPTION
## Description

This pull request fixes a 500 error from the DigitalOcean marketplace PATCH endpoint caused by `imageId` being sent as a quoted string. Removing the quotes around `${IMAGE_ID}` in the `update.json` file lets the value (already coerced to a number via `jq | tonumber)` serialize as a JSON integer, required by the API (https://github.com/digitalocean/marketplace-partners/blob/master/README.md#parameters)

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

